### PR TITLE
Add ”jekyll” format to output markdown suitable for the jekyll engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,37 +13,9 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - "12.4" # Swift 5.3
+          - "13.1" # Swift 5.5.1
 
     name: "macOS Big Sur (Xcode ${{ matrix.xcode }})"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        with:
-          path: .build
-          key: ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-
-      - name: Install System Dependencies
-        run: |
-          brew bundle
-      - name: Build and Test
-        run: |
-          swift test -c release
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
-
-  macos_catalina:
-    runs-on: macos-10.15
-
-    strategy:
-      matrix:
-        xcode:
-          - "12.4" # Swift 5.3
-
-    name: "macOS Catalina (Xcode ${{ matrix.xcode }})"
 
     steps:
       - name: Checkout
@@ -68,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        swift: ["5.3"]
+        swift: ["5.5"]
 
     name: "Linux (Swift ${{ matrix.swift }})"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "CommonMark",
-        "repositoryURL": "https://github.com/SwiftDocOrg/CommonMark.git",
+        "repositoryURL": "https://github.com/qvik/CommonMark.git",
         "state": {
-          "branch": null,
-          "revision": "1c8f3983c12b848e0d84b3a7a1d6f9a735e6661a",
-          "version": "0.5.0"
+          "branch": "fix/linux-swift-5.5",
+          "revision": "6f8dc577dd07d263e819d30b10444ef6503d7640",
+          "version": null
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
         "state": {
           "branch": null,
-          "revision": "e9a73a30755c3c5b26ba7c73312b1f2ccb9a1a30",
-          "version": "0.4.0"
+          "revision": "74b6cbd8c5ecea9f64d84c4e1c88d65604dd033f",
+          "version": "0.4.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/Markup.git",
         "state": {
           "branch": null,
-          "revision": "029ad8c1115ab32b7c20ab52eb092fbc030deb17",
-          "version": "0.0.4"
+          "revision": "c36d9ca11240bae6e3f7f17d29b5cfe3356f97ca",
+          "version": "0.1.3"
         }
       },
       {
@@ -77,8 +77,8 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "release/5.4",
-          "revision": "d81b6a6dc2698a93dcc04304fb15a5446b5278a4",
+          "branch": "release/5.5",
+          "revision": "2ca29758ed04c0a209221db59f922d4faf539f03",
           "version": null
         }
       },
@@ -95,8 +95,8 @@
         "package": "SwiftSemantics",
         "repositoryURL": "https://github.com/SwiftDocOrg/SwiftSemantics.git",
         "state": {
-          "branch": "0.3.0",
-          "revision": "2f571ccc67e0789d23f8adbccb6a18a6ff3b166c",
+          "branch": "0.3.2",
+          "revision": "7690606eec5db6b089d6a5d252013ee07cade323",
           "version": null
         }
       },
@@ -104,8 +104,8 @@
         "package": "SwiftSyntaxHighlighter",
         "repositoryURL": "https://github.com/NSHipster/SwiftSyntaxHighlighter.git",
         "state": {
-          "branch": "1.2.2",
-          "revision": "175923d005df00dc76c3c191bd7977c066a5288c",
+          "branch": "1.2.4",
+          "revision": "ac89909534b2afa4e9626307191c0d277ff82fe8",
           "version": null
         }
       }

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("release/5.5")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .revision("0.3.2")),
-        .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.5.0")),
+        .package(url: "https://github.com/qvik/CommonMark.git", .branch("fix/linux-swift-5.5")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.1")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -14,6 +14,7 @@ extension SwiftDoc {
     enum Format: String, ExpressibleByArgument {
       case commonmark
       case html
+      case jekyll
     }
 
     struct Options: ParsableArguments {
@@ -119,6 +120,8 @@ extension SwiftDoc {
             filename = "Home.md"
           case .html:
             filename = "index.html"
+          case .jekyll:
+            filename = "index.md"
           }
 
           let url = outputDirectoryURL.appendingPathComponent(filename)
@@ -131,6 +134,8 @@ extension SwiftDoc {
             pages["_Footer"] = FooterPage(baseURL: baseURL)
           case .html:
             pages["Home"] = HomePage(module: module, externalTypes: Array(symbolsByExternalType.keys), baseURL: baseURL, symbolFilter: symbolFilter)
+          case .jekyll:
+            pages["Home"] = HomePage(module: module, externalTypes: Array(symbolsByExternalType.keys), baseURL: baseURL, symbolFilter: symbolFilter)
           }
 
           try pages.map { $0 }.parallelForEach {
@@ -142,6 +147,10 @@ extension SwiftDoc {
               filename = "index.html"
             case .html:
               filename = "\(path(for: $0.key))/index.html"
+            case .jekyll where $0.key == "Home":
+              filename = "index.md"
+            case .jekyll:
+              filename = "\(path(for: $0.key)).md"
             }
 
             let url = outputDirectoryURL.appendingPathComponent(filename)

--- a/Sources/swift-doc/Supporting Types/Components/Documentation.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Documentation.swift
@@ -7,7 +7,7 @@ import HypertextLiteral
 import SwiftSyntaxHighlighter
 import Xcode
 
-struct Documentation: Component {
+struct Documentation: HypertextLiteralConvertible {
     var symbol: Symbol
     var module: Module
     let baseURL: String
@@ -22,11 +22,14 @@ struct Documentation: Component {
 
     // MARK: - Component
 
-    var fragment: Fragment {
+    func fragment(style: CommonMarkStyle) -> Fragment {
         guard let documentation = symbol.documentation else { return Fragment { "" } }
 
         return Fragment {
-            if !symbol.conditions.isEmpty {
+            // Jekyll does not render markdown inside the <dd> tag correctly
+            let useDescriptionList = style != .jekyll && !symbol.conditions.isEmpty
+            
+            if useDescriptionList {
                 Fragment {
                     #"""
                     <dl>
@@ -70,7 +73,7 @@ struct Documentation: Component {
                 }
             }
 
-            if !symbol.conditions.isEmpty {
+            if useDescriptionList {
                 Fragment {
                     #"""
 

--- a/Sources/swift-doc/Supporting Types/Components/Members.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Members.swift
@@ -4,7 +4,7 @@ import SwiftMarkup
 import SwiftSemantics
 import HypertextLiteral
 
-struct Members: Component {
+struct Members: HypertextLiteralConvertible {
     var symbol: Symbol
     var module: Module
     let baseURL: String
@@ -57,7 +57,7 @@ struct Members: Component {
 
     // MARK: - Component
 
-    var fragment: Fragment {
+    func fragment(style: CommonMarkStyle) -> Fragment {
         guard !members.isEmpty || !defaultImplementations.isEmpty else { return Fragment { "" } }
 
         return Fragment {
@@ -70,7 +70,7 @@ struct Members: Component {
                             Heading {
                                 Code { member.name }
                             }
-                            Documentation(for: member, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+                            Documentation(for: member, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
                         }
                     }
                 }
@@ -87,7 +87,7 @@ struct Members: Component {
                             Section {
                                 ForEach(in: members) { member in
                                     Heading { member.name }
-                                    Documentation(for: member, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+                                    Documentation(for: member, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
                                 }
                             }
                         }

--- a/Sources/swift-doc/Supporting Types/Components/OperatorImplementations.swift
+++ b/Sources/swift-doc/Supporting Types/Components/OperatorImplementations.swift
@@ -4,7 +4,7 @@ import SwiftMarkup
 import SwiftSemantics
 import HypertextLiteral
 
-struct OperatorImplementations: Component {
+struct OperatorImplementations: HypertextLiteralConvertible {
     var symbol: Symbol
     var module: Module
     let baseURL: String
@@ -24,7 +24,7 @@ struct OperatorImplementations: Component {
 
     // MARK: - Component
 
-    var fragment: Fragment {
+    func fragment(style: CommonMarkStyle) -> Fragment {
         guard !implementations.isEmpty else { return Fragment { "" } }
 
         return Fragment {
@@ -32,7 +32,7 @@ struct OperatorImplementations: Component {
                 Section {
                     Heading { implementation.name }
 
-                    Documentation(for: implementation, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+                    Documentation(for: implementation, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
                 }
             }
         }

--- a/Sources/swift-doc/Supporting Types/Components/Requirements.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Requirements.swift
@@ -4,7 +4,7 @@ import SwiftMarkup
 import SwiftSemantics
 import HypertextLiteral
 
-struct Requirements: Component {
+struct Requirements: HypertextLiteralConvertible {
     var symbol: Symbol
     var module: Module
     let baseURL: String
@@ -26,7 +26,7 @@ struct Requirements: Component {
 
     // MARK: - Component
 
-    var fragment: Fragment {
+    func fragment(style: CommonMarkStyle) -> Fragment {
         guard !sections.isEmpty else { return Fragment { "" } }
 
         return Fragment {
@@ -36,7 +36,7 @@ struct Requirements: Component {
                     Section {
                         ForEach(in: section.requirements) { requirement in
                             Heading { requirement.name.escapingEmojiShortcodes }
-                            Documentation(for: requirement, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+                            Documentation(for: requirement, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
                         }
                     }
                 }

--- a/Sources/swift-doc/Supporting Types/JekyllFrontMatter.swift
+++ b/Sources/swift-doc/Supporting Types/JekyllFrontMatter.swift
@@ -1,0 +1,8 @@
+func jekyllFrontMatter(_ page: Page) -> String {
+    return """
+---
+title: \(page.title)
+---
+
+"""
+}

--- a/Sources/swift-doc/Supporting Types/Page.swift
+++ b/Sources/swift-doc/Supporting Types/Page.swift
@@ -6,11 +6,16 @@ import struct SwiftSemantics.Protocol
 import CommonMark
 import HypertextLiteral
 
+enum CommonMarkStyle {
+    case `default`
+    case jekyll
+}
+
 protocol Page: HypertextLiteralConvertible {
     var module: Module { get }
     var baseURL: String { get }
     var title: String { get }
-    var document: CommonMark.Document { get }
+    func document(style: CommonMarkStyle) -> CommonMark.Document
     var html: HypertextLiteral.HTML { get }
 }
 
@@ -24,9 +29,11 @@ extension Page {
         let data: Data?
         switch format {
         case .commonmark:
-            data = document.render(format: .commonmark).data(using: .utf8)
+            data = document(style: .default).render(format: .commonmark).data(using: .utf8)
         case .html:
             data = layout(self).description.data(using: .utf8)
+        case .jekyll:
+            data = (jekyllFrontMatter(self) + document(style: .jekyll).render(format: .commonmark)).data(using: .utf8)
         }
 
         guard let filedata = data else { return }

--- a/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
@@ -40,7 +40,7 @@ struct ExternalTypePage: Page {
         ].filter { !$0.members.isEmpty }
     }
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         Document {
             Heading { "Extensions on \(externalType)" }
             ForEach(in: sections) { section -> BlockConvertible in
@@ -52,7 +52,7 @@ struct ExternalTypePage: Page {
                             Heading {
                                 Code { member.name }
                             }
-                            Documentation(for: member, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+                            Documentation(for: member, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
                         }
                     }
                 }

--- a/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
@@ -28,7 +28,7 @@ struct FooterPage: Page {
 
     // MARK: - Page
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         let timestamp = timestampDateFormatter.string(from: Date())
 
         return Document {

--- a/Sources/swift-doc/Supporting Types/Pages/GlobalPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/GlobalPage.swift
@@ -24,11 +24,11 @@ struct GlobalPage: Page {
         return name
     }
     
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         return Document {
             ForEach(in: symbols) { symbol in
                 Heading { symbol.id.description }
-                Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+                Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
             }
         }
     }

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -66,7 +66,7 @@ struct HomePage: Page {
         return module.name
     }
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         return Document {
             ForEach(in: [
                 ("Types", classes + enumerations + structures),

--- a/Sources/swift-doc/Supporting Types/Pages/OperatorPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/OperatorPage.swift
@@ -25,11 +25,11 @@ struct OperatorPage: Page {
         return symbol.id.description
     }
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         return CommonMark.Document {
             Heading { symbol.id.description }
 
-            Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+            Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
         }
     }
 

--- a/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
@@ -50,7 +50,7 @@ struct SidebarPage: Page {
 
     // MARK: - Page
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         return Document {
             ForEach(in: (
                 [
@@ -82,7 +82,7 @@ struct SidebarPage: Page {
 
     var html: HypertextLiteral.HTML {
         #"""
-        \#(document)
+        \#(document(style: .default))
         """#
     }
 }

--- a/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
@@ -23,14 +23,14 @@ struct TypePage: Page {
         return symbol.id.description
     }
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         return CommonMark.Document {
             Heading { symbol.id.description }
 
-            Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+            Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
             Relationships(of: symbol, in: module, baseURL: baseURL, includingChildren: symbolFilter)
-            Members(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter)
-            Requirements(of: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+            Members(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter).fragment(style: style)
+            Requirements(of: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
         }
     }
 

--- a/Sources/swift-doc/Supporting Types/Pages/TypealiasPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypealiasPage.swift
@@ -23,10 +23,10 @@ struct TypealiasPage: Page {
         return symbol.id.description
     }
 
-    var document: CommonMark.Document {
+    func document(style: CommonMarkStyle) -> CommonMark.Document {
         Document {
             Heading { symbol.id.description }
-            Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter)
+            Documentation(for: symbol, in: module, baseURL: baseURL, includingOtherSymbols: symbolFilter).fragment(style: style)
         }
     }
 


### PR DESCRIPTION
Jekyll is mostly the same as CommonMark, but wants a "front matter" at that top of pages.

However, Jekyll does not render markdown inside `<dl><dd>` tags. As the `commonMark` format uses those when the symbol has requirements, that feature must be turned off when rendering for Jekyll.

To support that, the `document` property of `Page` was turned into a function taking a style argument. Similarly for the `fragment` property of `Documentation`, and recursively any other node using `Documentation`.

Implementation note: the "styleable" components no longer conform to `Component`. `Component` is a composition protocol of `HypertextLiteralConvertible` and `BlockConvertible`. The `BlockConvertible` conformance is no longer used, but `HypertextLiteralConvertible` remains, as no changes were made to that functionality.